### PR TITLE
Add SDK to collect metrics and fix deploy to bluemix

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -21,9 +21,13 @@ stages:
         type: deployer
         script: |-
             #!/bin/bash
-            cf create-service iotf-service iotf-service-free iotp-for-conveyor
+            cf create-service iotf-service iotf-service-free simulate-iot-iotf-service
+            cf create-service cloudantNoSQLDB Lite simulate-iot-cloudantNoSQLDB
+            cf create-service AvailabilityMonitoring Lite availability-monitoring-auto
             cf push ${CF_APP} --no-start
-            cf bind-service ${CF_APP} iotp-for-conveyor
+            cf bind-service ${CF_APP} simulate-iot-iotf-service
+            cf bind-service ${CF_APP} simulate-iot-cloudantNoSQLDB
+            cf bind-service ${CF_APP} availability-monitoring-auto
             cf restage ${CF_APP}
             cf start ${CF_APP}
         target:

--- a/README.md
+++ b/README.md
@@ -188,26 +188,27 @@ For more information about creating boards and cards, see [Visualizing real-time
 * [IBM Watson IoT Platform](http://www.ibm.com/internet-of-things/iot-solutions/watson-iot-platform/)   
 * [IBM Watson IoT Platform Developers Community](https://developer.ibm.com/iotplatform/)
 
-## Privacy notice
+## Privacy Notice
 
-This web application includes code to track deployments to [IBM Bluemix](https://www.bluemix.net/) and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
+Sample web applications that include this package may be configured to track deployments to [IBM Bluemix](https://www.bluemix.net/) and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
 
 * Node.js package version
 * Node.js repository URL
 * Application Name (`application_name`)
 * Application GUID (`application_id`)
 * Application instance index number (`instance_index`)
-* Space ID (`space_id`)
+* Space ID (`space_id`) or OS username
 * Application Version (`application_version`)
 * Application URIs (`application_uris`)
-* Labels of bound services
+* Cloud Foundry API (`cf_api`)
+* Labels and names of bound services
 * Number of instances for each bound service and associated plan information
 * Metadata in the repository.yaml file
 
 This data is collected from the `package.json` and `repository.yaml` file in the sample application and the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
 
 ## Disabling deployment tracking
-Deployment tracking can be disabled by removing the `require("metrics-tracker-client").track();` line from the './bin/www' file.
+Deployment tracking can be disabled by removing the `require("metrics-tracker-client").track();` line from the 'index.js' file.
 
 ## License
 [Apache 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Bluemix Deployments](https://metrics-tracker.mybluemix.net/stats/103baca0d9db927ea5e6decf1da19ff3/badge.svg)
+
 ![Architecture Diagram](images/steps-architecture.png)
 
 # Connecting a motor device as a simulated device
@@ -30,7 +32,7 @@ If you choose to use Git to download the code samples you must also have a [GitH
 ## Deploy to Bluemix
 If you want to deploy directly to Bluemix, click on 'Deploy to Bluemix' button below to create a Bluemix DevOps service toolchain and pipeline for deploying basic motor with an IoT device that sends monitoring data to Watson IoT Platform on Bluemix, else jump to [Steps](#steps)
 
-[![Deploy to Bluemix](images/deploy-btn.PNG)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM/simulate-iot)
+[![Deploy to Bluemix](https://metrics-tracker.mybluemix.net/stats/103baca0d9db927ea5e6decf1da19ff3/button.svg)](https://console.ng.bluemix.net/devops/setup/deploy/?repository=https://github.com/IBM/manage-control-device-node-red)
 
 After deploying the application, please continue with [Step 3 - See raw data in Watson IoT Platform](#step-3---see-raw-data-in-watson-iot-platform).
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var when = require("when");
 var bcrypt = require("bcrypt");
 var util = require("util");
 var path = require("path");
+require('metrics-tracker-client').track();
 
 
 util.log("Starting Node-RED on Bluemix bootstrap");

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
   instances: 1
   domain: mybluemix.net
   name: simulate-iot
-  host: simulate-iot
+  random-route: true
   disk_quota: 1024M
   services:
   - availability-monitoring-auto

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "express":"4.x",
         "body-parser":"1.x",
         "http-shutdown":"1.2.0",
+        "metrics-tracker-client": "*",
         "node-red": "0.x",
         "node-red-bluemix-nodes":"1.x",
         "node-red-node-watson":"0.x",

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,7 +1,10 @@
-id: simulate-iot
+id: manage-control-device-node-red
 event_id: web
 event_organizer: dev-journeys
 runtimes:
   - Cloud Foundry
 services:
-  - Watson IoT Platform
+  - Internet of Things Platform
+  - Cloudant NoSQL DB
+  - NodeRed
+language: nodejs


### PR DESCRIPTION
We would like to have this journey to sent metrics to our new tracker.

- Add the new tracker SDK package, SDK call, and the metadata file(repository.yaml)
- Add privacy notice

This PR also fix the following bugs:
- Use a random-route to avoid `host is taken` error
- Provision the correct services in `pipeline.yml` to match the `manifest.yml` requirements. 

cc @animeshsingh @hovig 